### PR TITLE
Add definition of static constexpr members

### DIFF
--- a/src/Stepper.cpp
+++ b/src/Stepper.cpp
@@ -3,6 +3,12 @@
 
 namespace TeensyStep
 {
+    constexpr int32_t Stepper::vMaxMax;
+    constexpr uint32_t Stepper::aMax;
+    constexpr uint32_t Stepper::vMaxDefault;
+    constexpr uint32_t Stepper::vPullInOutDefault;
+    constexpr uint32_t Stepper::aDefault;
+
     Stepper::Stepper(const int _stepPin, const int _dirPin)
         : current(0), stepPin(_stepPin), dirPin(_dirPin)
     {


### PR DESCRIPTION
Hi luni64,

TeensyStep wouldn't compile with optimizations switched off (for debugging purposes). Adding a definition to the `static constexpr` members of `Stepper` seems to help (cf. [here](https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char)).

Cheers,
Florian