### PR TITLE
fix: timers on STM32F411xE boards

### DIFF
--- a/library.json
+++ b/library.json
@@ -14,7 +14,7 @@
     "maintainer": true
   },
   "homepage": "https://luni64.github.io/TeensyStep",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "frameworks": "arduino",
   "platforms": ["Teensy", "stm32"]
 }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=TeensyStep
-version=2.3.1
+version=2.3.2
 author=luni64
 maintainer=luni64
 sentence=High speed stepper driver for PJRC Teensy boards (T3.0 - T3.6) and STM32F4

--- a/src/MotorControlBase.h
+++ b/src/MotorControlBase.h
@@ -27,6 +27,9 @@ namespace TeensyStep{
 
         void emergencyStop() { timerField.end(); }
 
+          // set callback function to be called when target is reached
+        void setCallback(void (*_callback)()) { this->callback = _callback; }
+
         virtual ~MotorControlBase();
 
         void attachErrorFunction(ErrFunc ef) { errFunc = ef; }
@@ -95,7 +98,7 @@ namespace TeensyStep{
     template <typename t>
     MotorControlBase<t>::MotorControlBase(unsigned pulseWidth, unsigned accUpdatePeriod)
         : timerField(this), mCnt(0)
-    {        
+    {
         timerField.setPulseWidth(pulseWidth);
         timerField.setAccUpdatePeriod(accUpdatePeriod);
         this->accUpdatePeriod = accUpdatePeriod;

--- a/src/RotateControlBase.h
+++ b/src/RotateControlBase.h
@@ -66,10 +66,10 @@ namespace TeensyStep
 
         this->leadMotor->currentSpeed = 0;
 
-        this->leadMotor->A = std::abs(this->leadMotor->vMax);
+        this->leadMotor->A = abs(this->leadMotor->vMax);
         for (int i = 1; i < N; i++)
         {
-            this->motorList[i]->A = std::abs(this->motorList[i]->vMax);
+            this->motorList[i]->A = abs(this->motorList[i]->vMax);
             this->motorList[i]->B = 2 * this->motorList[i]->A - this->leadMotor->A;
         }
         uint32_t acceleration = (*std::min_element(this->motorList, this->motorList + N, Stepper::cmpAcc))->a; // use the lowest acceleration for the move
@@ -113,7 +113,7 @@ namespace TeensyStep
             delayMicroseconds(this->pulseWidth); // dir signal need some lead time
         }
 
-        this->timerField.setStepFrequency(std::abs(newSpeed)); // speed changed, update timer
+        this->timerField.setStepFrequency(abs(newSpeed)); // speed changed, update timer
         this->leadMotor->currentSpeed = newSpeed;
     }
 

--- a/src/RotateControlBase.h
+++ b/src/RotateControlBase.h
@@ -93,6 +93,7 @@ namespace TeensyStep
             this->timerField.end();
             this->leadMotor->currentSpeed = 0;
             isStopping = false;
+            if (this->callback) this->callback();
             return;
         }
 

--- a/src/StepControlBase.h
+++ b/src/StepControlBase.h
@@ -56,8 +56,8 @@ namespace TeensyStep
 
         // Misc ---------------------------------------------------------
 
-        // set callback function to be called when target is reached
-        void setCallback(void (*_callback)()) { this->callback = _callback; }
+        // // set callback function to be called when target is reached
+         //void setCallback(void (*_callback)()) { this->callback = _callback; }
 
      protected:
         void accTimerISR();

--- a/src/StepControlBase.h
+++ b/src/StepControlBase.h
@@ -96,16 +96,16 @@ namespace TeensyStep
         uint32_t pullOutSpeed = this->leadMotor->vPullOut;
         uint32_t acceleration = (*std::min_element(this->motorList, this->motorList + N, Stepper::cmpAcc))->a; // use the lowest acceleration for the move
 
-        uint32_t targetSpeed = std::abs((*std::min_element(this->motorList, this->motorList + N, Stepper::cmpVmin))->vMax) * speedOverride; // use the lowest max frequency for the move, scale by relSpeed
+        uint32_t targetSpeed = abs((*std::min_element(this->motorList, this->motorList + N, Stepper::cmpVmin))->vMax) * speedOverride; // use the lowest max frequency for the move, scale by relSpeed
         if (this->leadMotor->A == 0 || targetSpeed == 0) return;
 
         // target speed----
 
         float x = 0;
-        float leadSpeed = std::abs(this->leadMotor->vMax);
+        float leadSpeed = abs(this->leadMotor->vMax);
         for (int i = 0; i < N; i++)
         {
-            float relDist = this->motorList[i]->A / (float)this->leadMotor->A * leadSpeed / std::abs(this->motorList[i]->vMax);
+            float relDist = this->motorList[i]->A / (float)this->leadMotor->A * leadSpeed / abs(this->motorList[i]->vMax);
             if (relDist > x) x = relDist;
            // Serial.printf("%d %f\n", i, relDist);
         }

--- a/src/Stepper.cpp
+++ b/src/Stepper.cpp
@@ -3,6 +3,12 @@
 
 namespace TeensyStep
 {
+    constexpr int32_t Stepper::vMaxMax;
+    constexpr uint32_t Stepper::aMax;
+    constexpr uint32_t Stepper::vMaxDefault;
+    constexpr uint32_t Stepper::vPullInOutDefault;
+    constexpr uint32_t Stepper::aDefault;
+
     Stepper::Stepper(const int _stepPin, const int _dirPin)
         : current(0), stepPin(_stepPin), dirPin(_dirPin)
     {

--- a/src/Stepper.h
+++ b/src/Stepper.h
@@ -51,8 +51,8 @@ namespace TeensyStep
         // compare functions
         static bool cmpDelta(const Stepper* a, const Stepper* b) { return a->A > b->A; }
         static bool cmpAcc(const Stepper* a, const Stepper* b) { return a->a < b->a; }
-        static bool cmpVmin(const Stepper* a, const Stepper* b) { return std::abs(a->vMax) < std::abs(b->vMax); }
-        static bool cmpVmax(const Stepper* a, const Stepper* b) { return std::abs(a->vMax) > std::abs(b->vMax); }
+        static bool cmpVmin(const Stepper* a, const Stepper* b) { return abs(a->vMax) < abs(b->vMax); }
+        static bool cmpVmax(const Stepper* a, const Stepper* b) { return abs(a->vMax) > abs(b->vMax); }
 
         // Pin & Dir registers
 #if defined(__MK20DX128__) || defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)

--- a/src/timer/stm32/TimerField.cpp
+++ b/src/timer/stm32/TimerField.cpp
@@ -1,6 +1,15 @@
 #if defined(STM32F4xx)
 #include "TimerField.h"
 int TimerField::instances = 0;
-TIM_TypeDef* TimerField::timer_mapping[MAX_TIMERS] = { TIM1, TIM2, TIM4, TIM5, TIM6, TIM7, TIM8, TIM9, TIM10, TIM11, TIM12, TIM14 };
+
 // TIM3 and TIM13 used by HAL/FreeRTOS? doesn't work well to use.
+
+// --- Different boards. See TimerField.h for more
+#if defined(STM32F429xx)
+TIM_TypeDef* TimerField::timer_mapping[MAX_TIMERS] = { TIM1, TIM2, TIM4, TIM5, TIM6, TIM7, TIM8, TIM9, TIM10, TIM11, TIM12, TIM14 };
+
+#elif defined(STM32F411xE)
+TIM_TypeDef* TimerField::timer_mapping[MAX_TIMERS] = { TIM1, TIM2, TIM4, TIM5, TIM9, TIM10, TIM11 };
+#endif
+
 #endif

--- a/src/timer/stm32/TimerField.h
+++ b/src/timer/stm32/TimerField.h
@@ -6,8 +6,15 @@
 
 #include "../TF_Handler.h"
 
-
+// --- Different boards:
+#if defined(STM32F429xx)
 #define MAX_TIMERS 12
+#elif defined(STM32F411xE)
+#define MAX_TIMERS 7
+#else
+#error Board not currently supported. See: https://github.com/luni64/TeensyStep/issues/137
+#endif
+
 class TimerField
 {
 public:


### PR DESCRIPTION
This PR fixes the `TimerField` for `STM32F411xE` boards such as the Nucleo F411RE board.

It preserves compatibility with the existing supported board (`STM32F429xx`) and introduces an error for boards that haven't been explicitly defined as working. Adding new boards is easy - simply look up the timers in the documentation and add the appropriate define clause.

Note that I have not run tests on `STM32F429xx`'s, as I don't have access to any. @ramboerik if you still have the hardware and feel like it, it would be fantastic if you could confirm that this works for your setup.